### PR TITLE
Updated syntax to work in python 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+/.idea
+/__pycache__

--- a/inputbox.py
+++ b/inputbox.py
@@ -55,7 +55,7 @@ def ask(screen, question, default='', password=0):
     "ask(screen, question) -> answer"
     pygame.font.init()
     current_string = list(default)
-    display_box(screen, question + ": " + string.join(current_string,""))
+    display_box(screen, question + ": " + "".join(current_string))
     while 1:
         inkey = get_key()
         if inkey == K_BACKSPACE:
@@ -71,12 +71,12 @@ def ask(screen, question, default='', password=0):
         if password:
             display_box(screen, question + ": " + "*"*len(current_string))
         else:
-            display_box(screen, question + ": " + string.join(current_string,""))
-    return string.join(current_string,"")
+            display_box(screen, question + ": " + "".join(current_string))
+    return "".join(current_string)
 
 def main():
   screen = pygame.display.set_mode((220,40))
   screen.fill((0,100,255))
-  print ask(screen, "Name") + " was entered"
+  print(ask(screen, "Name") + " was entered")
 
 if __name__ == '__main__': main()

--- a/rfb.py
+++ b/rfb.py
@@ -601,25 +601,25 @@ if __name__ == '__main__':
     class RFBTest(RFBClient):
         """dummy client"""
         def vncConnectionMade(self):
-            print "Screen format: depth=%d bytes_per_pixel=%r" % (self.depth, self.bpp)
-            print "Desktop name: %r" % self.name
+            print("Screen format: depth=%d bytes_per_pixel=%r" % (self.depth, self.bpp))
+            print("Desktop name: %r" % self.name)
             self.SetEncodings([RAW_ENCODING])
             self.FramebufferUpdateRequest()
         
         def updateRectangle(self, x, y, width, height, data):
-            print "%s " * 5 % (x, y, width, height, repr(data[:20]))
+            print("%s " * 5 % (x, y, width, height, repr(data[:20])))
     
     class RFBTestFactory(protocol.ClientFactory):
         """test factory"""
         protocol = RFBTest
         def clientConnectionLost(self, connector, reason):
-            print reason
+            print(reason)
             from twisted.internet import reactor
             reactor.stop()
             #~ connector.connect()
     
         def clientConnectionFailed(self, connector, reason):
-            print "connection failed:", reason
+            print("connection failed:", reason)
             from twisted.internet import reactor
             reactor.stop()
 
@@ -634,10 +634,10 @@ if __name__ == '__main__':
     o = Options()
     try:
         o.parseOptions()
-    except usage.UsageError, errortext:
-        print "%s: %s" % (sys.argv[0], errortext)
-        print "%s: Try --help for usage details." % (sys.argv[0])
-        raise SystemExit, 1
+    except usage.UsageError as errortext:
+        print("%s: %s" % (sys.argv[0], errortext))
+        print("%s: Try --help for usage details." % (sys.argv[0]))
+        raise SystemExit(1)
 
     logFile = sys.stdout
     if o.opts['outfile']:

--- a/vncviewer.py
+++ b/vncviewer.py
@@ -161,7 +161,7 @@ class PyGameApp:
             #then communicate that to the protocol...
         else:
             #~ self.screen = pygame.display.set_mode(self.area.size, winstyle, depth)
-            raise ValueError, "color depth not supported"
+            raise ValueError ("color depth not supported")
         self.background = pygame.Surface((self.width, self.height), depth)
         self.background.fill(0) #black
 
@@ -190,7 +190,7 @@ class PyGameApp:
                     elif e.unicode:
                         self.protocol.keyEvent(ord(e.unicode))
                     else:
-                        print "warning: unknown key %r" % (e)
+                        print("warning: unknown key %r" % (e))
                 elif e.type == KEYUP:
                     if e.key in MODIFIERS:
                         self.protocol.keyEvent(MODIFIERS[e.key], down=0)
@@ -311,10 +311,10 @@ class RFBToGUI(rfb.RFBClient):
         self.screen.fill(struct.unpack("BBBB", color), (x, y, width, height))
 
     def bell(self):
-        print "katsching"
+        print("katsching")
 
     def copy_text(self, text):
-        print "Clipboard: %r" % text
+        print("Clipboard: %r" % text)
 
 #use a derrived class for other depths. hopefully with better performance
 #that a single class with complicated/dynamic color conversion.
@@ -356,7 +356,7 @@ class VNCFactory(rfb.RFBFactory):
         elif depth == 8:
             self.protocol = RFBToGUIeightbits
         else:
-            raise ValueError, "color depth not supported"
+            raise ValueError("color depth not supported")
             
         if fast:
             self.encodings = [
@@ -412,10 +412,10 @@ def main():
     o = Options()
     try:
         o.parseOptions()
-    except usage.UsageError, errortext:
-        print "%s: %s" % (sys.argv[0], errortext)
-        print "%s: Try --help for usage details." % (sys.argv[0])
-        raise SystemExit, 1
+    except usage.UsageError as errortext:
+        print("%s: %s" % (sys.argv[0], errortext))
+        print("%s: Try --help for usage details." % (sys.argv[0]))
+        raise SystemExit(1)
 
     depth = int(o.opts['depth'])
 


### PR DESCRIPTION
Updated the syntax of such functions as `print`, `raise`, `.join`, and `except` to comply with newer versions of python
